### PR TITLE
A partial fix to use the good MAIL FROM directive when we transmit an email

### DIFF
--- a/lib/mti_gf.ml
+++ b/lib/mti_gf.ml
@@ -67,6 +67,59 @@ struct
       Server.serve_when_ready ?stop ~handler:(handler pool) service in
     fiber
 
+  let filter_on_domain ~domain fwd_path =
+    match fwd_path with
+    | Colombe.Forward_path.Postmaster -> true
+    | Domain (Domain vs) | Forward_path {Colombe.Path.domain= Domain vs; _} ->
+      let domain' = Domain_name.(host_exn (of_strings_exn vs)) in
+      Domain_name.equal domain domain'
+    | Domain _ | Forward_path _ -> false
+
+  let to_reverse_path ~domain = function
+    | Colombe.Forward_path.Postmaster ->
+      Some
+        (Some
+           {
+             Colombe.Path.local= `String "postmaster"
+           ; domain= Domain (Domain_name.to_strings domain)
+           ; rest= []
+           })
+    | Domain _ -> None
+    | Forward_path path -> Some (Some path)
+
+  (* NOTE(dinosaure): as the relay, we disturb the route of the email and the
+     receiver can fail on the SPF check. Imagine a relay with this association:
+     [foo@bar.com] -> [foo@gmail.com]. If a sender ([bar@foo.com]) sends an
+     email to [foo@bar.com], our [verifier] will be able to do a SPF
+     verification. Afterthat, the [verifier] will send back the incoming email
+     (with a new [Received-SPF] field) to our relay. The relay will find that
+     the real destination of the email is [foo@gmail.com]. In such situation,
+     we will talk to [gmail.com:25] which will do another SPF verification.
+
+     In such situation, the [MAIL FROM] given to [gmail.com:25] must have the
+     [bar.com] domain (our domain) to allow [gmail.com:25] to really check SPF
+     metadata. However, the initial [MAIL FROM] was [bar@foo.com]!
+
+     We must do a translation of the [MAIL FROM] which must correspond to the
+     initial destination ([foo@bar.com]) when we talk to [gmail.com:25]. It
+     complexify a bit the situation when:
+     1) we must verify that the initial destination ([foo@bar.com]) exists as
+        a user into our database
+     2) currently, we handles only one case: when we have **one** recipient with
+        our domain [bar.com] - mainly because we can have only one sender
+
+     If someone wants to send to [foo@bar.com] and [bar@bar.com], which
+     [MAIL FROM] we should use for real destinations? We obviously can associate
+     the [MAIL FROM] per destinations ([foo@bar.com] will be the [MAIL FROM] of
+     its destination, and the same appear for [bar@bar.com]). However,
+     [bar@bar.com] can be associate to [foo@gmail.com]... In that case, we have
+     2 users with the same destination and we fallback on the situation where
+     we can not really choose between [foo@bar.com] and [bar@bar.com] as the
+     expected [MAIL FROM] for [gmail.com:25]...
+
+     So currently, we handle the basic case where someone wants to send an email
+     to only one [@bar.com]. *)
+
   let smtp_logic ~pool ~info ~tls stack resolver messaged map =
     let rec go () =
       Relay.Md.await messaged >>= fun () ->
@@ -74,10 +127,24 @@ struct
       | None -> Lwt.pause () >>= go
       | Some ((key, _, _) as v) ->
         let transmit () =
+          let recipients = Ptt.Messaged.recipients key in
+          let translated_emitters =
+            List.map fst recipients
+            |> List.find_all (filter_on_domain ~domain:info.Ptt.SSMTP.domain)
+            |> List.filter_map (to_reverse_path ~domain:info.Ptt.SSMTP.domain)
+          in
+          let emitter =
+            match translated_emitters, map with
+            | [_emitter], None -> None
+            | [emitter], Some map ->
+              if Ptt.Relay_map.exists emitter map then Some emitter else None
+            | [], _ -> None
+            | _ :: _, _ ->
+              None (* TODO(dinosaure): see the huge comment above. *) in
           Relay.resolve_recipients ~domain:info.Ptt.SSMTP.domain resolver map
-            (List.map fst (Ptt.Messaged.recipients key))
-          >>= fun recipients -> transmit ~pool ~info ~tls stack v recipients
-        in
+            (List.map fst recipients)
+          >>= fun recipients ->
+          transmit ~pool ~info ~tls ?emitter stack v recipients in
         Lwt.async transmit
         ; Lwt.pause () >>= go in
     go ()

--- a/lib/ptt_transmit.ml
+++ b/lib/ptt_transmit.ml
@@ -150,7 +150,7 @@ struct
     let mx_ipaddrs = Ptt.Mxs.elements mxs |> sort in
     go mx_ipaddrs
 
-  let transmit ~pool ~info ~tls stack (key, queue, consumer) resolved =
+  let transmit ~pool ~info ~tls stack ?emitter (key, queue, consumer) resolved =
     let producers, targets =
       List.fold_left
         (fun (producers, targets) target ->
@@ -158,7 +158,7 @@ struct
           let stream () = Lwt_scheduler.inj (Lwt_stream.get stream) in
           producer :: producers, (stream, target) :: targets)
         ([], []) resolved in
-    let emitter, _ = Ptt.Messaged.from key in
+    let emitter = Option.value ~default:(fst (Ptt.Messaged.from key)) emitter in
     let transmit = plug_consumer_to_producers consumer producers in
     Log.debug (fun m ->
         m "Start to send the incoming email to %d recipient(s)."

--- a/lib/ptt_transmit.mli
+++ b/lib/ptt_transmit.mli
@@ -10,6 +10,7 @@ module Make
     -> info:Ptt.Logic.info
     -> tls:Tls.Config.client
     -> Stack.TCP.t
+    -> ?emitter:Colombe.Reverse_path.t
     -> Ptt.Messaged.key * Md.queue * Md.chunk Md.consumer
     -> ([ `Domain of [ `host ] Domain_name.t * Ptt.Mxs.t | `Ipaddr of Ipaddr.t ]
        * Ptt.Aggregate.resolved_elt)

--- a/lib/relay_map.ml
+++ b/lib/relay_map.ml
@@ -27,6 +27,15 @@ let add ~local mailbox t =
         Hashtbl.add t.map local [mailbox]
         ; t)
 
+let exists reverse_path t =
+  match reverse_path with
+  | None -> false
+  | Some {Colombe.Path.local; domain= Domain vs; _} ->
+    let domain' = Domain_name.(host_exn (of_strings_exn vs)) in
+    Domain_name.equal t.domain domain'
+    && Hashtbl.mem t.map (Colombe_emile.of_local local)
+  | _ -> false
+
 let recipients ~local {map; _} =
   match Hashtbl.find map local with
   | recipients -> recipients

--- a/lib/relay_map.mli
+++ b/lib/relay_map.mli
@@ -26,6 +26,9 @@ val empty : postmaster:Emile.mailbox -> domain:[ `host ] Domain_name.t -> t
 val add : local:Emile.local -> Emile.mailbox -> t -> t
 (** [add ~local mailbox m] appends a new deliver mailbox to [local] into [m]. *)
 
+val exists : Colombe.Reverse_path.t -> t -> bool
+(** [exists addr t] checks if [addr] exists into the given [t]. *)
+
 val recipients : local:Emile.local -> t -> Colombe.Forward_path.t list
 (** [recipients ~local m] returns all associated mailboxes to [local] in [m]. *)
 


### PR DESCRIPTION
Currently, the MAIL FROM used for the incoming email is transfered as is which can lead to an SPF error when when we send back the email to the real destination under our identity. This patch replace the MAIL FROM by the user under our identity to let the receiver to check correctly the SPF record from our identity.

Note that the verifier (in front of our infra) already wrote a Received-SPF of the real sender and already check the SPF of it. The real receiver can have a trace of the SPF result of the real sender even if we replaced it by our identity.

Partially solve #40 